### PR TITLE
feat: 商品テーブルのAddボタン

### DIFF
--- a/src/components/ProductTable/ProductTable.tsx
+++ b/src/components/ProductTable/ProductTable.tsx
@@ -6,6 +6,7 @@ import { columns } from './Columns';
 import { tableIcons } from './TableIcons';
 import { theme } from 'src/styles/theme';
 import { localization } from './Localization';
+import { AddBox } from '@material-ui/icons';
 
 const appHeaderHeight = 64;
 const padding = theme.spacing(3);
@@ -24,6 +25,16 @@ export const ProductTable: React.FC = () => {
           columns={columns}
           data={data?.sweets ?? []}
           icons={tableIcons}
+          actions={[
+            {
+              icon: () => <AddBox />,
+              isFreeAction: true,
+              position: 'toolbar',
+              onClick: () => {
+                alert('add!'); // TODO: これは消す。ここでdialogの表示・非表示を切り替える。
+              },
+            },
+          ]}
           components={{}}
           options={{
             headerStyle: {

--- a/src/components/ProductTable/ProductTableActions/AddProductAction/index.tsx
+++ b/src/components/ProductTable/ProductTableActions/AddProductAction/index.tsx
@@ -1,0 +1,3 @@
+export {}; //TODO: コンポーネントを実装したらこれは消す
+
+// export const AddProductDialog: React.FC = () => {...}


### PR DESCRIPTION
## 概要
- 商品テーブルに商品追加画面を表示するための＋ボタンを追加
- とりあえず、アラートがでるようになってます。

## 詳細
[![Image from Gyazo](https://i.gyazo.com/651f093cf4806e4ea21b5b5a667f82c0.gif)](https://gyazo.com/651f093cf4806e4ea21b5b5a667f82c0)


