### PR TITLE
feat: 404ページでドロワーを表示しない

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -21,7 +21,7 @@ const App: React.FC<AppProps> = ({ Component, pageProps, router }) => {
     }
   }, []);
 
-  const withOutAppDrawer = withOutAppDrawerPathnames.includes(router.pathname);
+  const withOutAppDrawer = withOutAppDrawerPathnames.includes(router.pathname) || Component.displayName === 'ErrorPage';
 
   return (
     <>


### PR DESCRIPTION
## 概要

404エラーページでドロワーを表示しないようにした．
