### PR TITLE
手動で追加したスイーツの削除＆作成機能のバグ修正

### DIFF
--- a/src/components/ProductTable/Localization.ts
+++ b/src/components/ProductTable/Localization.ts
@@ -25,6 +25,7 @@ export const localization: Localization = {
     editRow: {
       cancelTooltip: 'キャンセル',
       saveTooltip: '保存',
+      deleteText: '本当に削除しますか？この操作を後から取り消すことはできません。',
     },
   },
 };

--- a/src/components/ProductTable/TableIcons.tsx
+++ b/src/components/ProductTable/TableIcons.tsx
@@ -1,7 +1,7 @@
 import { forwardRef } from 'react';
 import {
   AddBox,
-  DeleteOutline,
+  Delete,
   Edit,
   Check,
   Clear,
@@ -16,7 +16,7 @@ import { Icons } from 'material-table';
 
 export const tableIcons: Icons = {
   Add: forwardRef<SVGSVGElement>((props, ref) => <AddBox {...props} ref={ref} />),
-  Delete: forwardRef<SVGSVGElement>((props, ref) => <DeleteOutline {...props} ref={ref} />),
+  Delete: forwardRef<SVGSVGElement>((props, ref) => <Delete {...props} ref={ref} />),
   Edit: forwardRef<SVGSVGElement>((props, ref) => <Edit {...props} ref={ref} />),
   Check: forwardRef<SVGSVGElement>((props, ref) => <Check {...props} ref={ref} />),
   Clear: forwardRef<SVGSVGElement>((props, ref) => <Clear {...props} ref={ref} />),

--- a/src/lib/api/axios.ts
+++ b/src/lib/api/axios.ts
@@ -2,4 +2,5 @@ import axios from 'axios';
 
 export default axios.create({
   baseURL: process.env.NEXT_PUBLIC_API_URI,
+  validateStatus: (status) => status < 500,
 });

--- a/src/lib/api/requests/deleteSweetRequest.ts
+++ b/src/lib/api/requests/deleteSweetRequest.ts
@@ -1,0 +1,22 @@
+import axios from '../axios';
+import { Sweet } from '../models/Sweet';
+import nookies from 'nookies';
+
+type DeleteSweetPath = {
+  id: Sweet['id'];
+};
+
+export async function deleteSweetRequest({ id }: DeleteSweetPath) {
+  try {
+    const cookies = nookies.get();
+
+    return await axios.delete<null>(`/sweets/${id}`, {
+      headers: {
+        Authorization: `bearer ${cookies.token}`,
+      },
+    });
+  } catch (e) {
+    console.log('deleteSweetRequest error', e);
+    return null;
+  }
+}

--- a/src/lib/api/requests/useCoupons.ts
+++ b/src/lib/api/requests/useCoupons.ts
@@ -6,13 +6,12 @@ type GetCouponsResponse = {
 };
 
 export function useCoupons() {
-  const { data, response, error, isValidating, revalidate, mutate } = useRequest<GetCouponsResponse, Error>({
+  const { data, error, isValidating, revalidate, mutate } = useRequest<GetCouponsResponse, Error>({
     url: '/coupons',
   });
 
   return {
     data,
-    response,
     error,
     isValidating,
     revalidate,


### PR DESCRIPTION
## 概要

closes #

## 詳細

- アプリから追加したスイーツのみ削除できる
- 公式から取り込んだスイーツは削除できない

## 次やること
- 手動で登録したスイーツの全ての情報を編集できるようにする
  - 現状カテゴリだけ編集できる